### PR TITLE
JS: fix typo in YLogScale

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -164,7 +164,7 @@ function addPlots(graph, conf) {
 	    labelStr += (labelStr == '' ? '' : ', ') + l;
 	}
 	conf.options.scales.yLeft = {
-	    type: graph.YlogScale ? 'logarithmic' : 'linear',
+	    type: graph.YLogScale ? 'logarithmic' : 'linear',
 	    position: 'left',
 	    title: {display: true, text: labelStr},
 	};
@@ -180,7 +180,7 @@ function addPlots(graph, conf) {
 	    labelStr += (labelStr == '' ? '' : ', ') + l;
 	}
 	conf.options.scales.yRight = {
-	    type: graph.YlogScale ? 'logarithmic' : 'linear',
+	    type: graph.YLogScale ? 'logarithmic' : 'linear',
 	    position: 'right',
 	    title: {display: true, text: labelStr},
 	};


### PR DESCRIPTION
This caused Y axis to be always "linear", even when XLogScale was always set.

Resolves #81 .