### PR TITLE
DB: make public Reader constraints work when assigned

### DIFF
--- a/db/constraints.go
+++ b/db/constraints.go
@@ -24,8 +24,6 @@ type Constraints struct {
 	Categories     map[string]struct{}
 	Sectors        map[string]struct{}
 	Industries     map[string]struct{}
-	Start          Date
-	End            Date
 }
 
 // NewConstraints creates a new Constraints with no constraints.
@@ -97,18 +95,6 @@ func (c *Constraints) Industry(inds ...string) *Constraints {
 	return c
 }
 
-// StartAt adds start date to the Constraints.
-func (c *Constraints) StartAt(dt Date) *Constraints {
-	c.Start = dt
-	return c
-}
-
-// EndAt adds end date to the Constraints.
-func (c *Constraints) EndAt(dt Date) *Constraints {
-	c.End = dt
-	return c
-}
-
 // CheckTicker whether it satisfies the constraints.
 func (c *Constraints) CheckTicker(ticker string) bool {
 	if len(c.ExcludeTickers) > 0 {
@@ -152,31 +138,4 @@ func (c *Constraints) CheckTickerRow(r TickerRow) bool {
 		}
 	}
 	return true
-}
-
-// CheckDates checks that the date range is entirely within the constrained
-// range. Both ends are inclusive.
-func (c *Constraints) CheckDates(start, end Date) bool {
-	if !c.Start.IsZero() && start.Before(c.Start) {
-		return false
-	}
-	if !c.End.IsZero() && end.After(c.End) {
-		return false
-	}
-	return true
-}
-
-// CheckAction whether it satisfies the constraints.
-func (c *Constraints) CheckAction(r ActionRow) bool {
-	return c.CheckDates(r.Date, r.Date)
-}
-
-// CheckPrice whether it satisfies the constraints.
-func (c *Constraints) CheckPrice(r PriceRow) bool {
-	return c.CheckDates(r.Date, r.Date)
-}
-
-// CheckResampled whether it satisfies the constraints.
-func (c *Constraints) CheckResampled(r ResampledRow) bool {
-	return c.CheckDates(r.DateOpen, r.DateClose)
 }

--- a/db/constraints_test.go
+++ b/db/constraints_test.go
@@ -24,17 +24,12 @@ func TestConstraints(t *testing.T) {
 	t.Parallel()
 
 	Convey("Constraints work correctly", t, func() {
-		beforeStart := NewDate(2020, 1, 1)
-		start := NewDate(2020, 2, 1)
-		end := NewDate(2020, 11, 31)
-		afterEnd := NewDate(2021, 1, 1)
 		tc := NewConstraints().ExcludeTicker("E").Ticker("A", "B", "E")
 		tc = tc.Exchange("NASDAQ", "NYSE")
 		tc = tc.Name("Fat Ducks", "Plumb & Plumber")
 		tc = tc.Category("Do", "Break")
 		tc = tc.Sector("Domestic", "Foreign")
 		tc = tc.Industry("Food", "Waste")
-		tc = tc.StartAt(start).EndAt(end)
 
 		Convey("CheckTicker", func() {
 			So(tc.CheckTicker("A"), ShouldBeTrue)
@@ -72,24 +67,6 @@ func TestConstraints(t *testing.T) {
 			So(tc.CheckTickerRow(ticker), ShouldBeFalse)
 			ticker.Industry = "Waste"
 			So(tc.CheckTickerRow(ticker), ShouldBeTrue)
-		})
-
-		Convey("CheckAction", func() {
-			So(tc.CheckAction(TestAction(start, 1.0, 1.0, true)), ShouldBeTrue)
-			So(tc.CheckAction(TestAction(end, 1.0, 1.0, true)), ShouldBeTrue)
-			So(tc.CheckAction(TestAction(beforeStart, 1.0, 1.0, true)), ShouldBeFalse)
-			So(tc.CheckAction(TestAction(afterEnd, 1.0, 1.0, true)), ShouldBeFalse)
-		})
-
-		Convey("CheckPrice", func() {
-			So(tc.CheckPrice(TestPrice(start, 10.0, 10.0, 100.0, true)), ShouldBeTrue)
-			So(tc.CheckPrice(TestPrice(afterEnd, 10.0, 10.0, 100.0, true)), ShouldBeFalse)
-		})
-
-		Convey("CheckResampled", func() {
-			So(tc.CheckResampled(ResampledRow{DateOpen: start, DateClose: end}), ShouldBeTrue)
-			So(tc.CheckResampled(ResampledRow{DateOpen: beforeStart, DateClose: end}), ShouldBeFalse)
-			So(tc.CheckResampled(ResampledRow{DateOpen: start, DateClose: afterEnd}), ShouldBeFalse)
 		})
 	})
 }


### PR DESCRIPTION
Previously, `Constraints` field had to be rebuilt before calling `Tickers()` or other access methods, and the config-visible fields were used only at `InitMessage` time. Now, constraints are rebuilt from the config fields every time `Tickers` is called, and the other access methods directly use the `Start` and `End` fields. This makes these fields effective immediately when they are assigned.

Part of #95 .