### PR TITLE
DB: accumulate abs. log-profits in monthly data

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -134,36 +135,42 @@ func TestDB(t *testing.T) {
 				{
 					DateOpen:           NewDate(2020, 1, 3),
 					DateClose:          NewDate(2020, 1, 15),
+					Open:               100.0,
 					OpenSplitAdjusted:  50.0,
+					OpenFullyAdjusted:  50.0,
 					Close:              102.0,
 					CloseSplitAdjusted: 51.0,
 					CloseFullyAdjusted: 51.0,
 					CashVolume:         4000.0,
-					SumRelativeMove:    5.0/50.0 + 4.0/55.0,
+					SumAbsLogProfits:   float32(math.Log(55.0)-math.Log(50.0)) + float32(math.Log(55.0)-math.Log(51.0)),
 					NumSamples:         3,
 					Active:             true,
 				},
 				{
 					DateOpen:           NewDate(2020, 2, 5),
 					DateClose:          NewDate(2020, 2, 7),
+					Open:               130.0,
 					OpenSplitAdjusted:  65.0,
+					OpenFullyAdjusted:  65.0,
 					Close:              150.0,
 					CloseSplitAdjusted: 75.0,
 					CloseFullyAdjusted: 75.0,
 					CashVolume:         3000.0,
-					SumRelativeMove:    5.0/65.0 + 5.0/70.0,
+					SumAbsLogProfits:   float32(math.Log(75.0) - math.Log(65.0)),
 					NumSamples:         3,
 					Active:             false,
 				},
 				{
 					DateOpen:           NewDate(2020, 3, 1),
 					DateClose:          NewDate(2020, 3, 1),
+					Open:               160.0,
 					OpenSplitAdjusted:  80.0,
+					OpenFullyAdjusted:  80.0,
 					Close:              160.0,
 					CloseSplitAdjusted: 80.0,
 					CloseFullyAdjusted: 80.0,
 					CashVolume:         500.0,
-					SumRelativeMove:    0.0,
+					SumAbsLogProfits:   0.0,
 					NumSamples:         1,
 					Active:             true,
 				},

--- a/db/schema.go
+++ b/db/schema.go
@@ -401,9 +401,6 @@ func TestResampled(dateOpen, dateClose Date, open, close, adj, dv float32, activ
 // of consecutive monthly bars.
 func DailyVolatility(rows []ResampledRow) (volatility float64, samples uint16) {
 	absLogProfit := func(x, y float32) float64 {
-		if y <= 0.0 {
-			return 0.0
-		}
 		diff := math.Log(float64(x)) - math.Log(float64(y))
 		if diff < 0.0 {
 			return -diff

--- a/db/schema.go
+++ b/db/schema.go
@@ -17,6 +17,7 @@ package db
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/stockparfait/errors"
@@ -358,37 +359,74 @@ func TestPrice(date Date, close, adj, dv float32, active bool) PriceRow {
 }
 
 // ResampledRow is a multi-day bar with some additional daily statistics.  Size:
-// 36 bytes.
+// 44 bytes.
 type ResampledRow struct {
+	Open               float32
 	OpenSplitAdjusted  float32
+	OpenFullyAdjusted  float32
 	Close              float32 // unadjusted
 	CloseSplitAdjusted float32 // adjusted only for splits
 	CloseFullyAdjusted float32 // adjusted for splits, dividends, spinoffs
 	CashVolume         float32
 	DateOpen           Date
 	DateClose          Date
-	// Sum of relative daily movements within the bar: sum(|p(t+1)-p(t)|/p(t)).
-	// Note, that it always has NumSamples-1 samples. When summing over multiple
-	// resampled bars, recover the missing sample as (open(t)-close(t-1))/open(t).
-	SumRelativeMove float32
-	NumSamples      uint16
-	Active          bool // if ticker is active at bar's close
+	// Sum of absolute values of daily log-profits within the bar:
+	// sum(abs(log(p(t+1))-log(p(t)))).  Note, that it always has NumSamples-1
+	// samples. When summing over multiple resampled bars, recover the missing
+	// sample as abs(log(open(t))-log(close(t-1))).
+	SumAbsLogProfits float32
+	NumSamples       uint16
+	Active           bool // if ticker is active at bar's close
 }
 
 // TestResampled creates a new ResampledRow for use in tests.
 func TestResampled(dateOpen, dateClose Date, open, close, adj, dv float32, active bool) ResampledRow {
 	return ResampledRow{
+		Open:               open,
 		OpenSplitAdjusted:  open,
+		OpenFullyAdjusted:  open,
 		Close:              close,
 		CloseSplitAdjusted: adj,
 		CloseFullyAdjusted: adj,
 		CashVolume:         dv,
 		DateOpen:           dateOpen,
 		DateClose:          dateClose,
-		SumRelativeMove:    0.2,
+		SumAbsLogProfits:   0.2,
 		NumSamples:         20,
 		Active:             active,
 	}
+}
+
+// DailyVolatility computes the average daily absolute log-profit from the list
+// of consecutive monthly bars.
+func DailyVolatility(rows []ResampledRow) (volatility float64, samples uint16) {
+	absLogProfit := func(x, y float32) float64 {
+		if y <= 0.0 {
+			return 0.0
+		}
+		diff := math.Log(float64(x)) - math.Log(float64(y))
+		if diff < 0.0 {
+			return -diff
+		}
+		return diff
+	}
+
+	var total float64
+	var prevRow ResampledRow
+	for i, r := range rows {
+		if i > 0 && r.OpenFullyAdjusted > 0.0 && prevRow.CloseFullyAdjusted > 0.0 {
+			total += absLogProfit(r.OpenFullyAdjusted, prevRow.CloseFullyAdjusted)
+			samples++
+		}
+		total += float64(r.SumAbsLogProfits)
+		samples += r.NumSamples - 1
+		prevRow = r
+	}
+	if samples == 0 {
+		return 0.0, 0
+	}
+	volatility = total / float64(samples)
+	return
 }
 
 // Metadata is the schema for the metadata.json file.

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -202,12 +202,12 @@ func TestSchema(t *testing.T) {
 				So(samples, ShouldEqual, 59)
 				So(testutil.RoundFixed(v, 2), ShouldEqual, 0.01)
 			})
-		})
 
-		Convey("empty rows", func() {
-			v, samples := DailyVolatility(nil)
-			So(samples, ShouldEqual, 0)
-			So(v, ShouldEqual, 0.0)
+			Convey("empty rows", func() {
+				v, samples := DailyVolatility(nil)
+				So(samples, ShouldEqual, 0)
+				So(v, ShouldEqual, 0.0)
+			})
 		})
 	})
 

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -178,7 +178,7 @@ func TestSchema(t *testing.T) {
 
 	Convey("ResampledRow", t, func() {
 		Convey("has correct size", func() {
-			So(unsafe.Sizeof(ResampledRow{}), ShouldEqual, 36)
+			So(unsafe.Sizeof(ResampledRow{}), ShouldEqual, 44)
 		})
 
 		Convey("TestResampled works", func() {
@@ -186,6 +186,28 @@ func TestSchema(t *testing.T) {
 			dc := NewDate(2019, 4, 1)
 			r := TestResampled(do, dc, 10.0, 11.0, 5.0, 1000.0, true)
 			So(r.Close, ShouldEqual, 11.0)
+		})
+
+		Convey("DailyVolatility", func() {
+			Convey("regular case", func() {
+				rows := []ResampledRow{
+					TestResampled(NewDate(2020, 1, 1), NewDate(2020, 1, 31),
+						100.0, 110.0, 110.0, 1000.0, true),
+					TestResampled(NewDate(2020, 2, 1), NewDate(2020, 2, 29),
+						112.0, 120.0, 120.0, 1000.0, true),
+					TestResampled(NewDate(2020, 3, 1), NewDate(2020, 3, 31),
+						118.8, 130.0, 130.0, 1000.0, true),
+				}
+				v, samples := DailyVolatility(rows)
+				So(samples, ShouldEqual, 59)
+				So(testutil.RoundFixed(v, 2), ShouldEqual, 0.01)
+			})
+		})
+
+		Convey("empty rows", func() {
+			v, samples := DailyVolatility(nil)
+			So(samples, ShouldEqual, 0)
+			So(v, ShouldEqual, 0.0)
 		})
 	})
 


### PR DESCRIPTION
Also add unadjusted and fully adjusted open prices to the monthly bars.

Resolves #97.