### PR TITLE
DB: add Source column to TickerRow

### DIFF
--- a/db/constraints.go
+++ b/db/constraints.go
@@ -17,6 +17,7 @@ package db
 // Constraints to filter the tickers and their time series.  Zero value means no
 // constraints.
 type Constraints struct {
+	Sources        map[string]struct{}
 	Tickers        map[string]struct{}
 	ExcludeTickers map[string]struct{}
 	Exchanges      map[string]struct{}
@@ -29,6 +30,7 @@ type Constraints struct {
 // NewConstraints creates a new Constraints with no constraints.
 func NewConstraints() *Constraints {
 	return &Constraints{
+		Sources:        make(map[string]struct{}),
 		Tickers:        make(map[string]struct{}),
 		ExcludeTickers: make(map[string]struct{}),
 		Exchanges:      make(map[string]struct{}),
@@ -37,6 +39,14 @@ func NewConstraints() *Constraints {
 		Sectors:        make(map[string]struct{}),
 		Industries:     make(map[string]struct{}),
 	}
+}
+
+// Source adds sources to the constraints.
+func (c *Constraints) Source(sources ...string) *Constraints {
+	for _, s := range sources {
+		c.Sources[s] = struct{}{}
+	}
+	return c
 }
 
 // ExcludeTicker adds tickers to be ignored.
@@ -112,6 +122,11 @@ func (c *Constraints) CheckTicker(ticker string) bool {
 
 // CheckTickerRow whether it satisfies the constraints.
 func (c *Constraints) CheckTickerRow(r TickerRow) bool {
+	if len(c.Sources) > 0 {
+		if _, ok := c.Sources[r.Source]; !ok {
+			return false
+		}
+	}
 	if len(c.Exchanges) > 0 {
 		if _, ok := c.Exchanges[r.Exchange]; !ok {
 			return false

--- a/db/constraints_test.go
+++ b/db/constraints_test.go
@@ -24,7 +24,10 @@ func TestConstraints(t *testing.T) {
 	t.Parallel()
 
 	Convey("Constraints work correctly", t, func() {
-		tc := NewConstraints().ExcludeTicker("E").Ticker("A", "B", "E")
+		tc := NewConstraints()
+		tc = tc.Source("S1", "S2")
+		tc = tc.ExcludeTicker("E")
+		tc = tc.Ticker("A", "B", "E")
 		tc = tc.Exchange("NASDAQ", "NYSE")
 		tc = tc.Name("Fat Ducks", "Plumb & Plumber")
 		tc = tc.Category("Do", "Break")
@@ -40,12 +43,17 @@ func TestConstraints(t *testing.T) {
 
 		Convey("CheckTickerRow", func() {
 			ticker := TickerRow{
+				Source:   "S1",
 				Exchange: "NASDAQ",
 				Name:     "Fat Ducks",
 				Category: "Do",
 				Sector:   "Domestic",
 				Industry: "Food",
 			}
+			So(tc.CheckTickerRow(ticker), ShouldBeTrue)
+			ticker.Source = "ZZ"
+			So(tc.CheckTickerRow(ticker), ShouldBeFalse)
+			ticker.Source = "S2"
 			So(tc.CheckTickerRow(ticker), ShouldBeTrue)
 			ticker.Name = "Dumb & Dumber"
 			So(tc.CheckTickerRow(ticker), ShouldBeFalse)

--- a/db/db.go
+++ b/db/db.go
@@ -92,6 +92,7 @@ type Reader struct {
 	DB             string    `json:"DB" required:"true"` // specific DB in path
 	UseTickers     []string  `json:"tickers"`
 	ExcludeTickers []string  `json:"exclude tickers"`
+	Sources        []string  `json:"sources"`
 	Exchanges      []string  `json:"exchanges"`
 	Names          []string  `json:"names"`
 	Categories     []string  `json:"categories"`
@@ -131,6 +132,7 @@ func NewReader(dbPath, db string) *Reader {
 
 func (r *Reader) initConstraints() {
 	r.constraints = NewConstraints().
+		Source(r.Sources...).
 		Ticker(r.UseTickers...).
 		ExcludeTicker(r.ExcludeTickers...).
 		Exchange(r.Exchanges...).

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -291,6 +291,7 @@ func TestDB(t *testing.T) {
 			js := fmt.Sprintf(`{
   "DB path": "%s",
   "DB": "%s",
+  "sources": ["S1", "S2"],
   "tickers": ["A", "B"],
   "exclude tickers": ["B", "C"],
   "exchanges": ["E1", "E2"],
@@ -305,6 +306,7 @@ func TestDB(t *testing.T) {
 			So(r.cachePath(), ShouldEqual, dbPath)
 			r.initConstraints()
 			So(r.constraints, ShouldResemble, &Constraints{
+				Sources:        map[string]struct{}{"S1": {}, "S2": {}},
 				Tickers:        map[string]struct{}{"A": {}, "B": {}},
 				ExcludeTickers: map[string]struct{}{"B": {}, "C": {}},
 				Exchanges:      map[string]struct{}{"E1": {}, "E2": {}},

--- a/db/schema.go
+++ b/db/schema.go
@@ -278,6 +278,7 @@ func (d Date) InRange(start, end Date) bool {
 
 // TickerRow is a row in the tickers table.
 type TickerRow struct {
+	Source      string // where the ticker was downloaded, e.g. NDL table name
 	Exchange    string // the primary exchange trading this ticker
 	Name        string // the company name
 	Category    string

--- a/ndl/sharadar/sharadar.go
+++ b/ndl/sharadar/sharadar.go
@@ -107,6 +107,7 @@ func (d *Dataset) FetchTickers(ctx context.Context, tables ...TableName) error {
 			break
 		}
 		d.Tickers[t.Ticker] = db.TickerRow{
+			Source:      t.TableName,
 			Exchange:    t.Exchange,
 			Name:        t.Name,
 			Category:    t.Category,

--- a/ndl/sharadar/sharadar_test.go
+++ b/ndl/sharadar/sharadar_test.go
@@ -73,6 +73,7 @@ func TestSharadar(t *testing.T) {
 
 			expected := map[string]db.TickerRow{
 				"A": {
+					Source:      "SEP",
 					Exchange:    "Exch1",
 					Name:        "Name1",
 					Category:    "Cat1",
@@ -84,6 +85,7 @@ func TestSharadar(t *testing.T) {
 					Active:      true,
 				},
 				"B": {
+					Source:      "SFP",
 					Exchange:    "Exch2",
 					Name:        "Name2",
 					Category:    "Cat2",
@@ -95,6 +97,7 @@ func TestSharadar(t *testing.T) {
 					Active:      false,
 				},
 				"C": {
+					Source:      "SFP",
 					Exchange:    "Exch3",
 					Name:        "Name3",
 					Category:    "Cat3",


### PR DESCRIPTION
This allows co-habitation of multiple sources / data tables in the same dataset, and subsequent filtering of the sources for analysis. In particular, this is convenient for downloading both Sharadar tables but still constraining analysis e.g. to equities only.

Resolves #101.