### PR TITLE
Plot: validate plot data

### DIFF
--- a/plot/plot.go
+++ b/plot/plot.go
@@ -134,7 +134,7 @@ func NewSeriesPlot(ts *stats.Timeseries) (*Plot, error) {
 // the same length.
 func NewXYPlot(xs, ys []float64) (*Plot, error) {
 	if len(xs) != len(ys) {
-		return nil, errors.Reason("len(x)=%d != len(y)=%d", len(xs), len(ys))
+		return nil, errors.Reason("len(xs)=%d != len(ys)=%d", len(xs), len(ys))
 	}
 	for i := range xs {
 		if math.IsInf(xs[i], 0) || math.IsNaN(xs[i]) {

--- a/plot/plot_test.go
+++ b/plot/plot_test.go
@@ -127,18 +127,25 @@ func TestPlot(t *testing.T) {
 			}
 			ts2 := stats.NewTimeseries().Init(dates2, y2)
 
-			xyPlot1 := NewXYPlot(x1, y1).
-				SetYLabel("p1").
+			xyPlot1, err := NewXYPlot(x1, y1)
+			So(err, ShouldBeNil)
+			xyPlot1.SetYLabel("p1").
 				SetLegend("XY1").
 				SetChartType(ChartDashed).
 				SetLeftAxis(true)
 
-			timePlot1 := NewSeriesPlot(ts1).SetLegend("TS1").SetYLabel("t1").
+			timePlot1, err := NewSeriesPlot(ts1)
+			So(err, ShouldBeNil)
+			timePlot1.SetLegend("TS1").SetYLabel("t1").
 				SetLeftAxis(true)
 
-			xyPlot2 := NewXYPlot(x2, y2).SetLegend("XY2").SetYLabel("p2").
+			xyPlot2, err := NewXYPlot(x2, y2)
+			So(err, ShouldBeNil)
+			xyPlot2.SetLegend("XY2").SetYLabel("p2").
 				SetChartType(ChartScatter)
-			timePlot2 := NewSeriesPlot(ts2).SetLegend("TS2").SetYLabel("t2")
+			timePlot2, err := NewSeriesPlot(ts2)
+			So(err, ShouldBeNil)
+			timePlot2.SetLegend("TS2").SetYLabel("t2")
 
 			Convey("access methods work", func() {
 				xx, yy := xyPlot1.GetXY()
@@ -182,7 +189,9 @@ func TestPlot(t *testing.T) {
 			})
 
 			Convey("JSON conversion works", func() {
-				xyPlotBars := NewXYPlot(x2, y2).SetChartType(ChartBars)
+				xyPlotBars, err := NewXYPlot(x2, y2)
+				So(err, ShouldBeNil)
+				xyPlotBars.SetChartType(ChartBars)
 
 				So(Add(ctx, xyPlot1, "lines"), ShouldBeNil)
 				So(Add(ctx, timePlot1, "prices"), ShouldBeNil)


### PR DESCRIPTION
Make sure all the `float64` values are not `Inf` or `NaN`, and dates in series plots are not zero value.

Resolves #106.