### PR TITLE
Refactor integrals, add Histogram.AddWithWeight and var substitution

### DIFF
--- a/stats/README.md
+++ b/stats/README.md
@@ -40,9 +40,9 @@ enough samples in the area of interest, e.g. where `g(X)` is sufficiently large
 and significantly contributes to the integral. Therefore, it may be beneficial
 to replace each `x` in the vector `X` with another variable `t` uniformly
 distributed in `(-1..1)`, such that `x(t -> -1) -> -Inf`, `x(t -> 1) -> Inf`,
-`x(t)` is monotonically increasing and differentiable over the entire `R`, and
-the probability of "interesting" values of `x(t)` is significant, so the number
-of required samples can be reduced.
+`x(t)` is monotonically increasing and differentiable over `(-1..1)`, and the
+probability of "interesting" values of `x(t)` is significant, so the number of
+required samples can be reduced.
 
 Specificially, our `g(X)` will often be a unit function on a subspace, usually
 for computing a bucket value in a histogram for the `N`-compounded sample:
@@ -67,8 +67,9 @@ r = max(|low|, |high|)
 b=ceiling(sqrt(N))
 ```
 
-However, rather than computing each bucket value separately, we will be sampling
-`x` over the entire range using this method, and incrementing the appropriate
-bucket by `f(x(t))*x'(t)`, thus computing many `g(x)`'s in one go. The value of
-`r` in this case is the maximum absolute value in the buckets' range.
+However, rather than computing each bucket value separately, since we are
+effectively sampling `x` over the entire range, we can use every sample to
+increase the appropriate bucket by `f(x(t))*x'(t)`, thus computing many `g(x)`'s
+in one go. The value of `r` in this case is the maximum absolute value in the
+buckets' range.
 

--- a/stats/README.md
+++ b/stats/README.md
@@ -1,0 +1,62 @@
+# Statistics package
+
+## Variable substitution in Monte Carlo integration
+
+Given the original integral:
+
+```
+I = \integral_{x_min..x_max} f(x) dx
+```
+
+replace `x` by `x(t)`, so the integral becomes over `dt`:
+
+```
+I = integral_{t_min..t_max} f(x(t)) x'(t) dt
+```
+
+where `x(t_min) = x_min`, `x(t_max) = x_max`, and `x'(t) = dx/dt` is the
+derivative of `x(t)` over `t`.
+
+The interesting case supported here is an `N`-dimensional integral over a vector
+`X=(x_1, ..., x_N)` in `R^N`, that is the `N`-dimensional real hyperspace. The
+original integral is assumed to be of the form:
+
+```
+I = E[g(X)] = \integral g(X)*f(X)*dX
+```
+
+where `f(X)` is the p.d.f. of some multivariate distribution of `X`.  The
+simplest way to compute it is to generate random samples of `X` using the same
+distribution.  Then the integral `I` can be approximated as:
+
+```
+I ~= 1/N * sum_{i=1..K} g(X_i)
+```
+
+for `K` number of samples.
+
+In practice, the distribution `f(X)` may require too many samples to generate
+enough samples in the area of interest, e.g. where `g(X)` is sufficiently large
+and significantly contributes to the integral. Therefore, it may be beneficial
+to replace each `x` in the vector `X` with another variable `t` uniformly
+distributed in `(-1..1)`, such that `x(t -> -1) -> -Inf`, `x(t -> 1) -> Inf`,
+and `x(t)` is monotonically increasing and differentiable over the entire `R`.
+
+Specificially, our `g(X)` will often be a unit function on a subspace, for
+computing a bucket value in a histogram:
+
+g(X) = (sum(X) in [low .. high]) ? 1 : 0
+
+The substitution is
+```
+x(t) = r * t / (1 - t^(2*b))
+```
+
+where `r` controls the width of a near-uniform distribution of `x` values around
+zero, and `b` controls the portion of samples falling beyond the interval
+`[-r..r]`.
+
+However, rather than computing each bucket value separately, we will be sampling
+`x` over the entire range using this method, and incrementing the appropriate
+bucket by `f(x(t))*x'(t)`, thus computing many `g(x)`'s in one go.
+

--- a/stats/README.md
+++ b/stats/README.md
@@ -40,12 +40,16 @@ enough samples in the area of interest, e.g. where `g(X)` is sufficiently large
 and significantly contributes to the integral. Therefore, it may be beneficial
 to replace each `x` in the vector `X` with another variable `t` uniformly
 distributed in `(-1..1)`, such that `x(t -> -1) -> -Inf`, `x(t -> 1) -> Inf`,
-and `x(t)` is monotonically increasing and differentiable over the entire `R`.
+`x(t)` is monotonically increasing and differentiable over the entire `R`, and
+the probability of "interesting" values of `x(t)` is significant, so the number
+of required samples can be reduced.
 
-Specificially, our `g(X)` will often be a unit function on a subspace, for
-computing a bucket value in a histogram:
+Specificially, our `g(X)` will often be a unit function on a subspace, usually
+for computing a bucket value in a histogram for the `N`-compounded sample:
 
+```
 g(X) = (sum(X) in [low .. high]) ? 1 : 0
+```
 
 The substitution is
 ```
@@ -56,7 +60,15 @@ where `r` controls the width of a near-uniform distribution of `x` values around
 zero, and `b` controls the portion of samples falling beyond the interval
 `[-r..r]`.
 
+Empirically, for the `N`-sum over `[low..high]`, a good choice of parameters is:
+
+```
+r = max(|low|, |high|)
+b=ceiling(sqrt(N))
+```
+
 However, rather than computing each bucket value separately, we will be sampling
 `x` over the entire range using this method, and incrementing the appropriate
-bucket by `f(x(t))*x'(t)`, thus computing many `g(x)`'s in one go.
+bucket by `f(x(t))*x'(t)`, thus computing many `g(x)`'s in one go. The value of
+`r` in this case is the maximum absolute value in the buckets' range.
 

--- a/stats/buckets_test.go
+++ b/stats/buckets_test.go
@@ -187,28 +187,28 @@ func TestHistogram(t *testing.T) {
 
 	Convey("Histogram works", t, func() {
 		Convey("with linear buckets", func() {
-			b, err := NewBuckets(10, 0.0, 1000.0, LinearSpacing)
+			b, err := NewBuckets(12, -200.0, 1000.0, LinearSpacing)
 			So(err, ShouldBeNil)
 			h := NewHistogram(b)
 			for i := 0; i < 1000; i++ {
 				h.Add(float64(i))
 			}
 			So(h.Size(), ShouldEqual, 1000)
-			So(h.Buckets().N, ShouldEqual, 10)
+			So(h.Buckets().N, ShouldEqual, 12)
 			So(h.Counts(), ShouldResemble, []uint{
-				100, 100, 100, 100, 100, 100, 100, 100, 100, 100})
+				0, 0, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100})
 			So(h.Weights(), ShouldResemble, []float64{
-				100, 100, 100, 100, 100, 100, 100, 100, 100, 100})
+				0, 0, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100})
 			So(h.Count(5), ShouldEqual, 100)
-			So(h.Count(11), ShouldEqual, 0)
+			So(h.Count(13), ShouldEqual, 0)
 			So(h.Sums(), ShouldResemble, []float64{
-				4950, 14950, 24950, 34950, 44950, 54950, 64950, 74950, 84950, 94950})
-			So(h.Sum(5), ShouldEqual, 54950.0)
-			So(h.Sum(11), ShouldEqual, 0.0)
+				0, 0, 4950, 14950, 24950, 34950, 44950, 54950, 64950, 74950, 84950, 94950})
+			So(h.Sum(7), ShouldEqual, 54950.0)
+			So(h.Sum(13), ShouldEqual, 0.0)
 			So(h.Xs(), ShouldResemble, []float64{
-				49.5, 149.5, 249.5, 349.5, 449.5, 549.5, 649.5, 749.5, 849.5, 949.5})
+				-150, -50, 49.5, 149.5, 249.5, 349.5, 449.5, 549.5, 649.5, 749.5, 849.5, 949.5})
 			So(h.PDFs(), ShouldResemble, []float64{
-				0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001})
+				0, 0, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001})
 			So(h.Mean(), ShouldEqual, 499.5)                     // actual: 499.5
 			So(h.MAD(), ShouldEqual, 250.0)                      // actual: 250.0
 			So(testutil.Round(h.Sigma(), 3), ShouldEqual, 287.0) // actual: ~288.7
@@ -228,7 +228,7 @@ func TestHistogram(t *testing.T) {
 			Convey("from counts", func() {
 				h2 := NewHistogram(b)
 				So(h2.AddWeights([]float64{
-					0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1}), ShouldBeNil)
+					0, 0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1}), ShouldBeNil)
 				So(h.PDF(5), ShouldEqual, 0.001)
 			})
 

--- a/stats/distribution_test.go
+++ b/stats/distribution_test.go
@@ -75,18 +75,6 @@ func TestDistribution(t *testing.T) {
 			So(d.CDF(10.0), ShouldEqual, 1.0)
 		})
 
-		Convey("ExpectationMC is accurate on full range", func() {
-			one := func(x float64) float64 { return 1.0 }
-			e := ExpectationMC(one, d, math.Inf(-1), math.Inf(1), 1000, 0.01)
-			So(testutil.Round(e, 2), ShouldEqual, 1.0)
-		})
-
-		Convey("ExpectationMC is accurate on a subrange", func() {
-			one := func(x float64) float64 { return 1.0 }
-			e := ExpectationMC(one, d, -3.0, 3.0, 1000, 0.01)
-			So(testutil.Round(e, 2), ShouldEqual, 0.7)
-		})
-
 		Convey("From Rand", func() {
 			d := NewNormalDistribution(2.0, 3.0)
 			d.Seed(seed)

--- a/stats/integral.go
+++ b/stats/integral.go
@@ -1,0 +1,125 @@
+// Copyright 2022 Stock Parfait
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"math"
+)
+
+// PreciseEnough determines if the value of x with an estimated deviation is
+// within epsilon neighborhood of its true value. This can be used as a
+// termination criteria in iterative approximation methods when a desired
+// precision has been reached.
+//
+// Note, that epsilon provides a relative precision: the true value of x is
+// assumed to be within [x-dev..x+dev] interval, and the precision is reached
+// when dev/x < epsilon for |x| >= 1, otherwise dev < epsilon.
+func PreciseEnough(x, deviation, epsilon float64) bool {
+	if deviation <= 0 {
+		return true
+	}
+	if epsilon <= 0 {
+		return false
+	}
+	x = math.Abs(x)
+	if x < 1 {
+		x = 1
+	}
+	return deviation < epsilon*x
+}
+
+// ExpectationMC computes a (potentially partial) expectation integral:
+// \integral_{ low .. high } [ f(x) * d.Prob(x) * dx ] using the simple
+// Monte-Carlo method of sampling f(x) with the given distribution sampler and
+// computing the average. The bounds are inclusive. Note, that low may be -Inf,
+// and high may be +Inf.
+//
+// The sampling stops either when the maxIter samples have been reached, or when
+// the average relative deviation of the result becomes less than the required
+// precision.
+func ExpectationMC(f func(x float64) float64, random func() float64,
+	low, high float64, maxIter int, precision float64) float64 {
+	var count = 0
+	var sum, devSum, result float64
+
+	for i := 0; i < maxIter; i++ {
+		x := random()
+		prevRes := result
+		count++
+		if x < low || high < x {
+			continue
+		}
+		sum += f(x)
+		if count == 1 { // no useful prevRes yet
+			continue
+		}
+		result = sum / float64(count)
+		devSum += math.Abs(prevRes - result)
+		if PreciseEnough(result, devSum/float64(count), precision) {
+			break
+		}
+	}
+	return result
+}
+
+/// Methods for integral variable substitution in Monte Carlo integration.
+//
+// Given the original I = \integral_{x_min..x_max} f(x) dx, replace x by t: I =
+// integral_{t_min..t_max} f(x(t)) x'(t) dt, where x(t_min) = x_min, x(t_max) =
+// x_max, and x'(t) = dx/dt is the derivative of x(t) over t.
+//
+// The interesting case supported here is an N-dimensional integral over a
+// vector X=(x_1, ..., x_N) in R^N, that is the entire N-dimensional real
+// hyperspace. The original integral is assumed to be of the form:
+//
+// I = E[g(X)] = \integral g(X)*f(X)*dX
+//
+// where f(X) is a p.d.f. of a distribution. The simplest way to compute it is
+// to generate random samples of X using the same distribution; then:
+//
+// I ~= 1/N * sum_{i=1..K} g(X_i) for K number of such samples.
+//
+// In practice, the distribution f(X) may require too many samples to generate
+// enough samples in the area of interest, e.g. where g(X) is sufficiently large
+// and significantly contributes to the integral. Therefore, it may be
+// beneficial to replace it with another variable t uniformly distributed in
+// (-1..1), such that x(-1) = -Inf, x(1) = Inf, and x(t) is monotonically
+// increasing and differentiable over the entire R.
+//
+// Specificially, our g(X) will often be a unit function on a range, for
+// computing a bucket value in a histogram:
+//
+// g(x) = (x in [low .. high]) ? 1 : 0
+//
+// The substitution is x(t) = r * t / (1 - t^(2*b)), where r controls the width
+// of a near-uniform distribution of x values around zero, and b controls the
+// portion of samples falling beyond the interval [-r..r].
+//
+// However, rather than computing each bucket value separately, we will be
+// sampling x over the entire range using this method, and incrementing the
+// appropriate bucket by f(x(t))*x'(t), thus computing many g(x)'s in one go.
+
+// VarSubst computes the value of x(t) = r * t / (1 - t^(2*b)) to be used as a
+// variable substitution in an integral over x in (-Inf..Inf). The new bounds
+// for t become (-1..1), excluding the boundaries.
+func VarSubst(t, r, b float64) float64 {
+	return r * t / (1 - math.Pow(t*t, b))
+}
+
+// VarPrime is the value of x'(t), the first derivative of x(t).
+func VarPrime(t, r, b float64) float64 {
+	t2b := math.Pow(t, 2*b)
+	return r * (1 + (2*b-1)*t2b) / ((1 - t2b) * (1 - t2b))
+}

--- a/stats/integral.go
+++ b/stats/integral.go
@@ -74,48 +74,11 @@ func ExpectationMC(f func(x float64) float64, random func() float64,
 	return result
 }
 
-/// Methods for integral variable substitution in Monte Carlo integration.
-//
-// Given the original I = \integral_{x_min..x_max} f(x) dx, replace x by t: I =
-// integral_{t_min..t_max} f(x(t)) x'(t) dt, where x(t_min) = x_min, x(t_max) =
-// x_max, and x'(t) = dx/dt is the derivative of x(t) over t.
-//
-// The interesting case supported here is an N-dimensional integral over a
-// vector X=(x_1, ..., x_N) in R^N, that is the entire N-dimensional real
-// hyperspace. The original integral is assumed to be of the form:
-//
-// I = E[g(X)] = \integral g(X)*f(X)*dX
-//
-// where f(X) is a p.d.f. of a distribution. The simplest way to compute it is
-// to generate random samples of X using the same distribution; then:
-//
-// I ~= 1/N * sum_{i=1..K} g(X_i) for K number of such samples.
-//
-// In practice, the distribution f(X) may require too many samples to generate
-// enough samples in the area of interest, e.g. where g(X) is sufficiently large
-// and significantly contributes to the integral. Therefore, it may be
-// beneficial to replace it with another variable t uniformly distributed in
-// (-1..1), such that x(-1) = -Inf, x(1) = Inf, and x(t) is monotonically
-// increasing and differentiable over the entire R.
-//
-// Specificially, our g(X) will often be a unit function on a range, for
-// computing a bucket value in a histogram:
-//
-// g(x) = (x in [low .. high]) ? 1 : 0
-//
-// The substitution is x(t) = r * t / (1 - t^(2*b)), where r controls the width
-// of a near-uniform distribution of x values around zero, and b controls the
-// portion of samples falling beyond the interval [-r..r].
-//
-// However, rather than computing each bucket value separately, we will be
-// sampling x over the entire range using this method, and incrementing the
-// appropriate bucket by f(x(t))*x'(t), thus computing many g(x)'s in one go.
-
 // VarSubst computes the value of x(t) = r * t / (1 - t^(2*b)) to be used as a
 // variable substitution in an integral over x in (-Inf..Inf). The new bounds
 // for t become (-1..1), excluding the boundaries.
 func VarSubst(t, r, b float64) float64 {
-	return r * t / (1 - math.Pow(t*t, b))
+	return r * t / (1 - math.Pow(t, 2*b))
 }
 
 // VarPrime is the value of x'(t), the first derivative of x(t).

--- a/stats/integral_test.go
+++ b/stats/integral_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Stock Parfait
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stockparfait/testutil"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestIntegral(t *testing.T) {
+	var seed uint64 = 42
+
+	Convey("PreciseEnough works", t, func() {
+		So(PreciseEnough(3.1415, 0.0314, 0.01), ShouldBeTrue)
+		So(PreciseEnough(3.1415, 0.0315, 0.01), ShouldBeFalse)
+		So(PreciseEnough(0.31415, 0.011, 0.01), ShouldBeFalse)
+		So(PreciseEnough(0.31415, 0.01, 0.011), ShouldBeTrue)
+	})
+
+	Convey("ExpectationMC integration is accurate", t, func() {
+		data := []float64{
+			-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 6.0}
+		buckets, err := NewBuckets(5, -5.0, 5.0, LinearSpacing)
+		So(err, ShouldBeNil)
+		d := NewSampleDistribution(data, buckets)
+		d.Seed(seed)
+
+		Convey("on the full range", func() {
+			one := func(x float64) float64 { return 1.0 }
+			e := ExpectationMC(one, d.Rand, math.Inf(-1), math.Inf(1), 1000, 0.01)
+			So(testutil.Round(e, 2), ShouldEqual, 1.0)
+		})
+
+		Convey("on a subrange", func() {
+			var calls int
+			one := func(x float64) float64 { calls++; return 1.0 }
+			e := ExpectationMC(one, d.Rand, -3.0, 3.0, 1000, 0.01)
+			So(testutil.Round(e, 2), ShouldEqual, 0.7)
+			So(calls, ShouldBeGreaterThan, 1)
+		})
+	})
+
+	Convey("Variable substitution methods work", t, func() {
+		Convey("VarSubst covers is symmetric and large near -1 and 1", func() {
+			So(VarSubst(0, 5, 2), ShouldEqual, 0)
+			So(testutil.Round(VarSubst(0.5, 5, 2), 3), ShouldEqual, 2.67)
+			So(testutil.Round(VarSubst(-0.5, 5, 2), 3), ShouldEqual, -2.67)
+			So(testutil.Round(VarSubst(0.999, 5, 2), 3), ShouldEqual, 1250)
+			So(testutil.Round(VarSubst(-0.999, 5, 2), 3), ShouldEqual, -1250)
+		})
+
+		Convey("VarPrime is indeed a derivative", func() {
+			t := 0.5
+			dt := 0.001
+			r, b := 5.0, 2.0
+			dx := VarSubst(t+dt/2.0, r, b) - VarSubst(t-dt/2.0, r, b)
+			So(testutil.Round(dx/dt, 5), ShouldEqual,
+				testutil.Round(VarPrime(t, r, b), 5))
+		})
+
+	})
+}

--- a/stats/integral_test.go
+++ b/stats/integral_test.go
@@ -57,7 +57,7 @@ func TestIntegral(t *testing.T) {
 	})
 
 	Convey("Variable substitution methods work", t, func() {
-		Convey("VarSubst covers is symmetric and large near -1 and 1", func() {
+		Convey("VarSubst is symmetric and large near -1 and 1", func() {
 			So(VarSubst(0, 5, 2), ShouldEqual, 0)
 			So(testutil.Round(VarSubst(0.5, 5, 2), 3), ShouldEqual, 2.67)
 			So(testutil.Round(VarSubst(-0.5, 5, 2), 3), ShouldEqual, -2.67)


### PR DESCRIPTION
These are needed for an upcoming biased sampling of a histogram for compounded distributions.

Part of #119.