### PR TITLE
Create a stub for parfait-import app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-INSTALLS=./apps/parfait-sharadar ./apps/parfait-list
+INSTALLS=./apps/parfait-sharadar ./apps/parfait-list ./apps/parfait-import
 GOPATH=$(shell go env GOPATH)
 
 CHARTJS_VERSION=v3.8.0

--- a/apps/parfait-import/main.go
+++ b/apps/parfait-import/main.go
@@ -31,8 +31,8 @@ type Flags struct {
 	// Exactly one of tickers, prices or update-metadata must be present
 	Tickers        string // Import tickers; merge by default
 	Replace        bool   // Replace tickers table rather than merge
-	Ticker         string // Must be present with -prices.
-	Prices         string // ticker to print prices for
+	Ticker         string // Must be present with -prices
+	Prices         string // Import prices for a given ticker
 	Schema         string // schema file for either tickers or prices table
 	UpdateMetadata bool
 }
@@ -50,7 +50,7 @@ func parseFlags(args []string) (*Flags, error) {
 	fs.BoolVar(&flags.Replace, "replace", false,
 		"replace the entire tickers table, don't merge")
 	fs.StringVar(&flags.Ticker, "ticker", "", "required with -prices")
-	fs.StringVar(&flags.Prices, "prices", "", "import prices for the given ticker")
+	fs.StringVar(&flags.Prices, "prices", "", "import prices for a given ticker")
 	fs.StringVar(&flags.Schema, "schema", "", "schema config for either tickers or prices")
 	fs.BoolVar(&flags.UpdateMetadata, "update-metadata", false, "scan the DB")
 

--- a/apps/parfait-import/main.go
+++ b/apps/parfait-import/main.go
@@ -1,0 +1,103 @@
+// Copyright 2022 Stock Parfait
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+
+	"github.com/stockparfait/errors"
+	"github.com/stockparfait/logging"
+)
+
+type Flags struct {
+	DBDir    string // default: ~/.stockparfait
+	DBName   string // required
+	LogLevel logging.Level
+	// Exactly one of tickers, prices or update-metadata must be present
+	Tickers        string // Import tickers; merge by default
+	Replace        bool   // Replace tickers table rather than merge
+	Ticker         string // Must be present with -prices.
+	Prices         string // ticker to print prices for
+	Schema         string // schema file for either tickers or prices table
+	UpdateMetadata bool
+}
+
+func parseFlags(args []string) (*Flags, error) {
+	var flags Flags
+	fs := flag.NewFlagSet("parfait-import", flag.ExitOnError)
+	fs.StringVar(&flags.DBDir, "cache",
+		filepath.Join(os.Getenv("HOME"), ".stockparfait"),
+		"path to databases")
+	fs.StringVar(&flags.DBName, "db", "", "database name (required)")
+	flags.LogLevel = logging.Info
+	fs.Var(&flags.LogLevel, "log-level", "Log level: debug, info, warning, error")
+	fs.StringVar(&flags.Tickers, "tickers", "", "import tickers")
+	fs.BoolVar(&flags.Replace, "replace", false,
+		"replace the entire tickers table, don't merge")
+	fs.StringVar(&flags.Ticker, "ticker", "", "required with -prices")
+	fs.StringVar(&flags.Prices, "prices", "", "import prices for the given ticker")
+	fs.StringVar(&flags.Schema, "schema", "", "schema config for either tickers or prices")
+	fs.BoolVar(&flags.UpdateMetadata, "update-metadata", false, "scan the DB")
+
+	err := fs.Parse(args)
+	if err != nil {
+		return nil, err
+	}
+	if flags.DBName == "" {
+		return nil, errors.Reason("missing required -db argument")
+	}
+	kinds := 0
+	if flags.Tickers != "" {
+		kinds++
+	}
+	if flags.Prices != "" {
+		kinds++
+	}
+	if flags.UpdateMetadata {
+		kinds++
+	}
+	if kinds != 1 {
+		return nil, errors.Reason(
+			"expected exactly one of -tickers, -prices or -update-metadata")
+	}
+	if flags.Prices != "" && flags.Ticker == "" {
+		return nil, errors.Reason("-ticker is required with -prices")
+	}
+	return &flags, err
+}
+
+func run(args []string) error {
+	flags, err := parseFlags(args)
+	if err != nil {
+		return errors.Annotate(err, "failed to parse flags")
+	}
+	ctx := context.Background()
+	ctx = logging.Use(ctx, logging.DefaultGoLogger(flags.LogLevel))
+	logging.Infof(ctx, "not yet implemented")
+	return nil
+}
+
+// main is not tested, keep it short.
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		ctx := context.Background()
+		ctx = logging.Use(ctx, logging.DefaultGoLogger(logging.Info))
+		logging.Errorf(ctx, err.Error())
+		os.Exit(1)
+	}
+}

--- a/apps/parfait-import/main_test.go
+++ b/apps/parfait-import/main_test.go
@@ -66,9 +66,7 @@ func TestMain(t *testing.T) {
 		})
 
 		Convey("-prices without -ticker", func() {
-			_, err := parseFlags([]string{
-				"-cache", "path/to/cache", "-db", "name",
-				"-log-level", "warning", "-prices", "prices.csv"})
+			_, err := parseFlags([]string{"-db", "name", "-prices", "prices.csv"})
 			So(err, ShouldNotBeNil)
 		})
 

--- a/apps/parfait-import/main_test.go
+++ b/apps/parfait-import/main_test.go
@@ -1,0 +1,112 @@
+// Copyright 2022 Stock Parfait
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stockparfait/logging"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func writeFile(fileName, content string) error {
+	f, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write([]byte(content))
+	return err
+}
+
+func TestMain(t *testing.T) {
+	t.Parallel()
+
+	Convey("parseFlags", t, func() {
+		Convey("-tickers", func() {
+			flags, err := parseFlags([]string{
+				"-cache", "path/to/cache", "-db", "name",
+				"-log-level", "warning", "-tickers", "tickers.csv"})
+			So(err, ShouldBeNil)
+			So(flags.DBDir, ShouldEqual, "path/to/cache")
+			So(flags.DBName, ShouldEqual, "name")
+			So(flags.LogLevel, ShouldEqual, logging.Warning)
+			So(flags.Tickers, ShouldEqual, "tickers.csv")
+			So(flags.Prices, ShouldEqual, "")
+			So(flags.UpdateMetadata, ShouldBeFalse)
+		})
+
+		Convey("-prices with -ticker", func() {
+			flags, err := parseFlags([]string{
+				"-db", "name", "-prices", "prices.csv", "-ticker", "ABC"})
+			So(err, ShouldBeNil)
+			So(flags.DBName, ShouldEqual, "name")
+			So(flags.LogLevel, ShouldEqual, logging.Info)
+			So(flags.Prices, ShouldEqual, "prices.csv")
+			So(flags.Ticker, ShouldEqual, "ABC")
+			So(flags.Tickers, ShouldEqual, "")
+			So(flags.UpdateMetadata, ShouldBeFalse)
+		})
+
+		Convey("-prices without -ticker", func() {
+			_, err := parseFlags([]string{
+				"-cache", "path/to/cache", "-db", "name",
+				"-log-level", "warning", "-prices", "prices.csv"})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("-update-metada", func() {
+			flags, err := parseFlags([]string{"-db", "name", "-update-metadata"})
+			So(err, ShouldBeNil)
+			So(flags.DBName, ShouldEqual, "name")
+			So(flags.Prices, ShouldEqual, "")
+			So(flags.Tickers, ShouldEqual, "")
+			So(flags.UpdateMetadata, ShouldBeTrue)
+		})
+
+		Convey("Incompatible flags", func() {
+			_, err := parseFlags([]string{
+				"-db", "name", "-prices", "prices.csv", "-update-metadata"})
+			So(err, ShouldNotBeNil)
+		})
+	})
+
+	Convey("run works", t, func() {
+		tmpdir, tmpdirErr := ioutil.TempDir("", "testmain")
+		defer os.RemoveAll(tmpdir)
+
+		So(tmpdirErr, ShouldBeNil)
+
+		tickersFile := filepath.Join(tmpdir, "tickers.csv")
+		// pricesFile := filepath.Join(tmpdir, "prices.csv")
+		// schemaFile := filepath.Join(tmpdir, "schema.json")
+
+		Convey("merge tickers", func() {
+			So(writeFile(tickersFile, `
+Ticker,Source,Exchange,Name,Category,Sector,Industry,Location,SEC Filings,Company Site,Active
+ABC,TEST,Exch,ABC Co.,Cat,Sec,Ind,Over Here,sec.gov,abc.com,TRUE
+CBA,TEST,Exch2,CBA Co.,Cat2,Sec2,Ind2,Over There,sec.gov,cba.com,FALSE
+`),
+				ShouldBeNil)
+			db := "testdb"
+			So(run([]string{"-cache", tmpdir, "-db", db, "-tickers", tickersFile}), ShouldBeNil)
+		})
+	})
+}

--- a/apps/parfait-list/main.go
+++ b/apps/parfait-list/main.go
@@ -42,7 +42,7 @@ type Flags struct {
 
 func parseFlags(args []string) (*Flags, error) {
 	var flags Flags
-	fs := flag.NewFlagSet("parfaitlist", flag.ExitOnError)
+	fs := flag.NewFlagSet("parfait-list", flag.ExitOnError)
 	fs.StringVar(&flags.DBDir, "cache",
 		filepath.Join(os.Getenv("HOME"), ".stockparfait"),
 		"path to databases")

--- a/apps/parfait-sharadar/main.go
+++ b/apps/parfait-sharadar/main.go
@@ -36,7 +36,7 @@ type Flags struct {
 
 func parseFlags(args []string) (*Flags, error) {
 	var flags Flags
-	fs := flag.NewFlagSet("sharadar", flag.ExitOnError)
+	fs := flag.NewFlagSet("parfait-sharadar", flag.ExitOnError)
 	fs.StringVar(&flags.DBDir, "cache",
 		filepath.Join(os.Getenv("HOME"), ".stockparfait"),
 		"path to databases")


### PR DESCRIPTION
Also, rename flag sets in other apps to `parfait-<name>`, to reflect the app names.

Part of #129 .