### PR TITLE
DB: prepare API for incremental updates

### DIFF
--- a/apps/parfait-list/main_test.go
+++ b/apps/parfait-list/main_test.go
@@ -75,7 +75,7 @@ func TestMain(t *testing.T) {
 		So(w.WriteActions(actions), ShouldBeNil)
 		So(w.WritePrices("A", pricesA), ShouldBeNil)
 		So(w.WriteMonthly(monthly), ShouldBeNil)
-		So(w.WriteMetadata(), ShouldBeNil)
+		So(w.WriteMetadata(w.Metadata), ShouldBeNil)
 
 		ctx := context.Background()
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -118,7 +118,7 @@ func TestDB(t *testing.T) {
 			So(w.WritePrices("A", pricesA), ShouldBeNil)
 			So(w.WritePrices("B", pricesB), ShouldBeNil)
 			So(w.WriteMonthly(monthly), ShouldBeNil)
-			So(w.WriteMetadata(), ShouldBeNil)
+			So(w.WriteMetadata(w.Metadata), ShouldBeNil)
 		})
 
 		Convey("ComputeMonthly works", func() {

--- a/db/schema.go
+++ b/db/schema.go
@@ -562,6 +562,36 @@ type Metadata struct {
 	NumMonthly int  `json:"num_monthly"` // monthly price samples
 }
 
+func (m *Metadata) UpdateTickers(tickers map[string]TickerRow) {
+	m.NumTickers = len(tickers)
+}
+
+func (m *Metadata) UpdateActions(actions map[string][]ActionRow) {
+	m.NumActions = 0
+	for _, as := range actions {
+		m.NumActions += len(as)
+	}
+}
+
+func (m *Metadata) UpdatePrices(prices []PriceRow) {
+	m.NumPrices += len(prices)
+	for _, p := range prices {
+		if m.Start.IsZero() || m.Start.After(p.Date) {
+			m.Start = p.Date
+		}
+		if m.End.IsZero() || m.End.Before(p.Date) {
+			m.End = p.Date
+		}
+	}
+}
+
+func (m *Metadata) UpdateMonthly(monthly map[string][]ResampledRow) {
+	m.NumMonthly = 0
+	for _, ms := range monthly {
+		m.NumMonthly += len(ms)
+	}
+}
+
 // Time is a wrapper around time.Time with JSON methods.
 type Time time.Time
 

--- a/ndl/sharadar/sharadar.go
+++ b/ndl/sharadar/sharadar.go
@@ -426,7 +426,7 @@ func (d *Dataset) DownloadAll(ctx context.Context, dbPath, dbName string, tables
 		return errors.Annotate(err, "failed to write monthly prices")
 	}
 	logging.Infof(ctx, "writing metadata...")
-	if err := w.WriteMetadata(); err != nil {
+	if err := w.WriteMetadata(w.Metadata); err != nil {
 		return errors.Annotate(err, "failed to write metadata")
 	}
 	logging.Infof(ctx, "all done.")


### PR DESCRIPTION
- `Reader` now exports cached tickers, actions and monthly resamples that can be subsequently written by the `Writer`;
- `Metadata` can update itself outside of `Writer`.

Part of #129.