### PR TITLE
DB: Remove actions

### DIFF
--- a/apps/parfait-list/main_test.go
+++ b/apps/parfait-list/main_test.go
@@ -54,11 +54,6 @@ func TestMain(t *testing.T) {
 			"A": {Source: "test", Active: true},
 			"B": {Source: "test", Active: false},
 		}
-		actions := map[string][]db.ActionRow{
-			"A": {
-				db.TestAction(db.NewDate(2019, 1, 1), 1.0, 1.0, true),
-			},
-		}
 		pricesA := []db.PriceRow{
 			db.TestPrice(db.NewDate(2019, 1, 1), 10.0, 10.0, 1000.0, true),
 			db.TestPrice(db.NewDate(2019, 1, 2), 11.0, 11.0, 1100.0, true),
@@ -72,7 +67,6 @@ func TestMain(t *testing.T) {
 		}
 		w := db.NewWriter(tmpdir, dbName)
 		So(w.WriteTickers(tickers), ShouldBeNil)
-		So(w.WriteActions(actions), ShouldBeNil)
 		So(w.WritePrices("A", pricesA), ShouldBeNil)
 		So(w.WriteMonthly(monthly), ShouldBeNil)
 		So(w.WriteMetadata(w.Metadata), ShouldBeNil)
@@ -89,19 +83,6 @@ func TestMain(t *testing.T) {
 Ticker,Source,Exchange,Name,Category,Sector,Industry,Location,SEC Filings,Company Site,Active
 A,test,,,,,,,,,TRUE
 B,test,,,,,,,,,FALSE
-`)
-		})
-
-		Convey("actions", func() {
-			flags, err := parseFlags([]string{"-cache", tmpdir, "-db", dbName,
-				"-actions", "A"})
-			So(err, ShouldBeNil)
-			var buf bytes.Buffer
-			So(printData(ctx, flags, &buf), ShouldBeNil)
-			So("\n"+buf.String(), ShouldEqual, `
-      Date | Dividend Factor | Split Factor | Active
----------- | --------------- | ------------ | ------
-2019-01-01 |               1 |            1 |   TRUE
 `)
 		})
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -81,15 +81,6 @@ func TestDB(t *testing.T) {
 			"A": {},
 			"B": {},
 		}
-		actions := map[string][]ActionRow{
-			"A": {
-				TestAction(NewDate(2019, 1, 1), 1.0, 1.0, true),
-			},
-			"B": {
-				TestAction(NewDate(2019, 1, 1), 1.0, 1.0, true),
-				TestAction(NewDate(2020, 1, 1), 1.0, 1.0, false),
-			},
-		}
 		pricesA := []PriceRow{
 			TestPrice(NewDate(2019, 1, 1), 10.0, 10.0, 1000.0, true),
 			TestPrice(NewDate(2019, 1, 2), 11.0, 11.0, 1100.0, true),
@@ -114,7 +105,6 @@ func TestDB(t *testing.T) {
 		Convey("write methods work", func() {
 			w := NewWriter(tmpdir, dbName)
 			So(w.WriteTickers(tickers), ShouldBeNil)
-			So(w.WriteActions(actions), ShouldBeNil)
 			So(w.WritePrices("A", pricesA), ShouldBeNil)
 			So(w.WritePrices("B", pricesB), ShouldBeNil)
 			So(w.WriteMonthly(monthly), ShouldBeNil)
@@ -229,19 +219,6 @@ func TestDB(t *testing.T) {
 			So(len(tickers), ShouldEqual, 0)
 		})
 
-		Convey("action access methods work", func() {
-			db := NewReader(tmpdir, dbName)
-			a, err := db.Actions("A")
-			So(err, ShouldBeNil)
-			So(a, ShouldResemble, actions["A"])
-
-			db.End = NewDate(2019, 6, 1)
-
-			a, err = db.Actions("B")
-			So(err, ShouldBeNil)
-			So(a, ShouldResemble, actions["B"][:1])
-		})
-
 		Convey("price access methods work", func() {
 			db := NewReader(tmpdir, dbName)
 			p, err := db.Prices("A")
@@ -280,7 +257,6 @@ func TestDB(t *testing.T) {
 				Start:      NewDate(2019, 1, 1),
 				End:        NewDate(2019, 1, 3),
 				NumTickers: 2,
-				NumActions: 3,
 				NumPrices:  6,
 				NumMonthly: 4,
 			})

--- a/db/schema.go
+++ b/db/schema.go
@@ -340,39 +340,6 @@ func (r TickerRow) CSV() []string {
 	}
 }
 
-// ActionRow is a row in the actions table. Size: 16 bytes (13+padding).
-type ActionRow struct {
-	Date           Date
-	DividendFactor float32 // dividend adjustment factor (1.0 = no dividend)
-	SplitFactor    float32 // split adjustment factor (1.0 = no split)
-	Active         bool
-}
-
-var _ table.Row = ActionRow{}
-
-func (r ActionRow) CSV() []string {
-	return []string{
-		r.Date.String(),
-		float2str(r.DividendFactor),
-		float2str(r.SplitFactor),
-		bool2str(r.Active),
-	}
-}
-
-func ActionRowHeader() []string {
-	return []string{"Date", "Dividend Factor", "Split Factor", "Active"}
-}
-
-// TestAction creates an ActionRow for use in tests.
-func TestAction(date Date, dividend, split float32, active bool) ActionRow {
-	return ActionRow{
-		Date:           date,
-		DividendFactor: dividend,
-		SplitFactor:    split,
-		Active:         active,
-	}
-}
-
 // PriceRow is a row in the prices table. It is intended for daily price points.
 // Size: 20 bytes.
 //
@@ -557,20 +524,12 @@ type Metadata struct {
 	Start      Date `json:"start"` // the earliest available price date
 	End        Date `json:"end"`   // the latest available price date
 	NumTickers int  `json:"num_tickers"`
-	NumActions int  `json:"num_actions"`
 	NumPrices  int  `json:"num_prices"`  // daily price samples
 	NumMonthly int  `json:"num_monthly"` // monthly price samples
 }
 
 func (m *Metadata) UpdateTickers(tickers map[string]TickerRow) {
 	m.NumTickers = len(tickers)
-}
-
-func (m *Metadata) UpdateActions(actions map[string][]ActionRow) {
-	m.NumActions = 0
-	for _, as := range actions {
-		m.NumActions += len(as)
-	}
 }
 
 func (m *Metadata) UpdatePrices(prices []PriceRow) {

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -166,32 +166,6 @@ func TestSchema(t *testing.T) {
 		})
 	})
 
-	Convey("ActionRow", t, func() {
-		Convey("has correct size", func() {
-			So(unsafe.Sizeof(ActionRow{}), ShouldEqual, 16)
-		})
-
-		Convey("TestAction works", func() {
-			d := NewDate(2019, 1, 2)
-			So(TestAction(d, 0.98, 0.5, true), ShouldResemble,
-				ActionRow{
-					Date:           d,
-					DividendFactor: 0.98,
-					SplitFactor:    0.5,
-					Active:         true,
-				})
-		})
-
-		Convey("ActionRowHeader works", func() {
-			So(len(ActionRowHeader()), ShouldEqual, 4)
-		})
-
-		Convey("CSV works", func() {
-			a := TestAction(NewDate(2020, 4, 15), 1.01, 2.0, false)
-			So(a.CSV(), ShouldResemble, []string{"2020-04-15", "1.01", "2", "FALSE"})
-		})
-	})
-
 	Convey("PriceRow", t, func() {
 		Convey("has correct size", func() {
 			So(unsafe.Sizeof(PriceRow{}), ShouldEqual, 20)


### PR DESCRIPTION
Split and dividend actions turned out to be redundant, both in our DB format and in Nasdaq Data Link / Sharadar dataset, and both can be safely removed.

Resolves #131.