### PR TITLE
Fix error estimation in Histogram

### DIFF
--- a/stats/buckets_test.go
+++ b/stats/buckets_test.go
@@ -210,7 +210,8 @@ func TestHistogram(t *testing.T) {
 			So(h.PDFs(), ShouldResemble, []float64{
 				0, 0, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001})
 			So(testutil.RoundFixedSlice(h.StdErrors(), 10), ShouldResemble, []float64{
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+				0, 0, 2.8034e-06, 1.2032e-06, 9.131e-07, 7.913e-07, 7.11e-07,
+				6.394e-07, 5.624e-07, 4.73e-07, 3.607e-07, 1.852e-07})
 			So(h.Mean(), ShouldEqual, 499.5)                     // actual: 499.5
 			So(h.MAD(), ShouldEqual, 250.0)                      // actual: 250.0
 			So(testutil.Round(h.Sigma(), 3), ShouldEqual, 287.0) // actual: ~288.7

--- a/stats/distribution_test.go
+++ b/stats/distribution_test.go
@@ -297,6 +297,7 @@ func TestDistribution(t *testing.T) {
 			So(testutil.RoundSlice(actual, 1), ShouldResemble,
 				testutil.RoundSlice(expected, 1))
 			for i := 0; i < h.Buckets().N; i++ {
+				So(h.stdErrs[i].n, ShouldBeGreaterThan, 0)
 				So(h.StdError(i), ShouldBeGreaterThan, 0.0)
 				So(h.StdError(i), ShouldBeLessThan, 0.1)
 			}


### PR DESCRIPTION
Update error estimation for all buckets every n samples for an n-bucket histogram.

Resolves #144.