### PR TITLE
Histogram: estimate errors on merging histograms

### DIFF
--- a/stats/buckets.go
+++ b/stats/buckets.go
@@ -446,6 +446,8 @@ func (h *Histogram) AddHistogram(h2 *Histogram) error {
 	h.weightsTotal += h2.weightsTotal
 	h.sumTotal += h2.sumTotal
 	h.countsTotal += h2.countsTotal
+	h.countErr = 0
+	h.estimateErrors()
 	return nil
 }
 


### PR DESCRIPTION
Since histogram merging runs through all the buckets anyway, it doesn't add a significant complexity to run error estimation on every call.

Part of #144 .