### PR TITLE
Plot: add user facing configs for groups and graphs

### DIFF
--- a/plot/plot.go
+++ b/plot/plot.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stockparfait/errors"
 
 	"github.com/stockparfait/stockparfait/db"
+	"github.com/stockparfait/stockparfait/message"
 	"github.com/stockparfait/stockparfait/stats"
 )
 
@@ -646,4 +647,93 @@ func WriteJS(ctx context.Context, w io.Writer) error {
 		return errors.Reason("no Canvas in context")
 	}
 	return c.WriteJS(w)
+}
+
+// GraphConfig is a config message for a plot graph. It is intended to be used
+// primarily within GroupConfig.
+type GraphConfig struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	XLabel    string `json:"X label"`
+	YLogScale bool   `json:"log scale Y"`
+}
+
+var _ message.Message = &GraphConfig{}
+
+func (g *GraphConfig) InitMessage(js interface{}) error {
+	if err := message.Init(g, js); err != nil {
+		return errors.Annotate(err, "cannot parse graph")
+	}
+	if g.ID == "" {
+		return errors.Reason("graph must have a non-empty ID")
+	}
+	return nil
+}
+
+// GroupConfig is a config for a group of plots with a common X axis.
+type GroupConfig struct {
+	Timeseries bool           `json:"timeseries"`
+	ID         string         `json:"id"`
+	Title      string         `json:"title"` // default: same as ID
+	XLogScale  bool           `json:"log scale X"`
+	Graphs     []*GraphConfig `json:"graphs"`
+}
+
+var _ message.Message = &GroupConfig{}
+
+func (g *GroupConfig) InitMessage(js interface{}) error {
+	if err := message.Init(g, js); err != nil {
+		return errors.Annotate(err, "cannot parse group")
+	}
+	if g.ID == "" {
+		return errors.Reason("group must have a non-empty ID")
+	}
+	if g.Title == "" {
+		g.Title = g.ID
+	}
+	if len(g.Graphs) < 1 {
+		return errors.Reason("at least one graph is required in group '%s'",
+			g.ID)
+	}
+	if g.Timeseries && g.XLogScale {
+		return errors.Reason("timeseries group '%s' cannot have log-scale X",
+			g.ID)
+	}
+	return nil
+}
+
+// ConfigureGroups ensures that the Canvas contains the listed groups.
+func (c *Canvas) ConfigureGroups(groups []*GroupConfig) error {
+	for _, gc := range groups {
+		kind := KindXY
+		if gc.Timeseries {
+			kind = KindSeries
+		}
+		group := NewGroup(kind, gc.ID).SetXLogScale(gc.XLogScale)
+		group.SetTitle(gc.Title)
+		if err := c.AddGroup(group); err != nil {
+			return errors.Annotate(err, "cannot add group '%s'", gc.ID)
+		}
+		for _, gpc := range gc.Graphs {
+			graph, err := c.EnsureGraph(kind, gpc.ID, gc.ID)
+			if err != nil {
+				return errors.Annotate(err, "cannot ensure graph '%s' in group '%s'",
+					gpc.ID, gc.ID)
+			}
+			graph.SetTitle(gpc.Title).
+				SetXLabel(gpc.XLabel).
+				SetYLogScale(gpc.YLogScale)
+		}
+	}
+	return nil
+}
+
+// ConfigureGroups in the Canvas in context. It's an error if Canvas is not in
+// context.
+func ConfigureGroups(ctx context.Context, groups []*GroupConfig) error {
+	c := Get(ctx)
+	if c == nil {
+		return errors.Reason("no Canvas in context")
+	}
+	return c.ConfigureGroups(groups)
 }

--- a/plot/plot.go
+++ b/plot/plot.go
@@ -652,7 +652,7 @@ func WriteJS(ctx context.Context, w io.Writer) error {
 // GraphConfig is a config message for a plot graph. It is intended to be used
 // primarily within GroupConfig.
 type GraphConfig struct {
-	ID        string `json:"id"`
+	ID        string `json:"id" required:"true"`
 	Title     string `json:"title"`
 	XLabel    string `json:"X label"`
 	YLogScale bool   `json:"log scale Y"`
@@ -660,7 +660,7 @@ type GraphConfig struct {
 
 var _ message.Message = &GraphConfig{}
 
-func (g *GraphConfig) InitMessage(js interface{}) error {
+func (g *GraphConfig) InitMessage(js any) error {
 	if err := message.Init(g, js); err != nil {
 		return errors.Annotate(err, "cannot parse graph")
 	}
@@ -673,7 +673,7 @@ func (g *GraphConfig) InitMessage(js interface{}) error {
 // GroupConfig is a config for a group of plots with a common X axis.
 type GroupConfig struct {
 	Timeseries bool           `json:"timeseries"`
-	ID         string         `json:"id"`
+	ID         string         `json:"id" required:"true"`
 	Title      string         `json:"title"` // default: same as ID
 	XLogScale  bool           `json:"log scale X"`
 	Graphs     []*GraphConfig `json:"graphs"`
@@ -681,7 +681,7 @@ type GroupConfig struct {
 
 var _ message.Message = &GroupConfig{}
 
-func (g *GroupConfig) InitMessage(js interface{}) error {
+func (g *GroupConfig) InitMessage(js any) error {
 	if err := message.Init(g, js); err != nil {
 		return errors.Annotate(err, "cannot parse group")
 	}
@@ -702,7 +702,7 @@ func (g *GroupConfig) InitMessage(js interface{}) error {
 	return nil
 }
 
-// ConfigureGroups ensures that the Canvas contains the listed groups.
+// ConfigureGroups ensures that the Canvas contains the given groups.
 func (c *Canvas) ConfigureGroups(groups []*GroupConfig) error {
 	for _, gc := range groups {
 		kind := KindXY
@@ -728,8 +728,8 @@ func (c *Canvas) ConfigureGroups(groups []*GroupConfig) error {
 	return nil
 }
 
-// ConfigureGroups in the Canvas in context. It's an error if Canvas is not in
-// context.
+// ConfigureGroups for the Canvas in the context. It's an error if the context
+// has no Canvas.
 func ConfigureGroups(ctx context.Context, groups []*GroupConfig) error {
 	c := Get(ctx)
 	if c == nil {

--- a/plot/plot_test.go
+++ b/plot/plot_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stockparfait/stockparfait/db"
 	"github.com/stockparfait/stockparfait/stats"
+	"github.com/stockparfait/testutil"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -205,5 +206,40 @@ var DATA = {"Groups":[{"Kind":"KindXY","Title":"xy","XLogScale":true,"Graphs":[{
 ;`)
 			})
 		})
+	})
+
+	Convey("GroupConfig and GraphConfig", t, func() {
+		c := NewCanvas()
+		ctx := Use(context.Background(), c)
+		XYJSON := `
+{
+  "id": "real",
+  "title": "Real Group",
+  "log scale X": true,
+  "graphs": [
+    {"id": "r1", "title": "Real One", "X label": "points"},
+    {"id": "r2", "X label": "points", "log scale Y": true}
+  ]
+}`
+		SeriesJSON := `
+{
+  "id": "time",
+  "timeseries": true,
+  "graphs": [
+    {"id": "t1", "title": "Time One", "X label": "dates"},
+    {"id": "t2", "X label": "dates", "log scale Y": true}
+  ]
+}`
+		var groupXY, groupSeries GroupConfig
+		So(groupXY.InitMessage(testutil.JSON(XYJSON)), ShouldBeNil)
+		So(groupSeries.InitMessage(testutil.JSON(SeriesJSON)), ShouldBeNil)
+		So(ConfigureGroups(ctx, []*GroupConfig{&groupXY, &groupSeries}), ShouldBeNil)
+		So(len(c.Groups), ShouldEqual, 2)
+
+		So(c.Groups[0].Title, ShouldEqual, "Real Group")
+		So(len(c.Groups[0].Graphs), ShouldEqual, 2)
+
+		So(len(c.Groups[1].Graphs), ShouldEqual, 2)
+		So(c.Groups[1].Graphs[0].Title, ShouldEqual, "Time One")
 	})
 }

--- a/plot/plot_test.go
+++ b/plot/plot_test.go
@@ -208,7 +208,7 @@ var DATA = {"Groups":[{"Kind":"KindXY","Title":"xy","XLogScale":true,"Graphs":[{
 		})
 	})
 
-	Convey("GroupConfig and GraphConfig", t, func() {
+	Convey("GroupConfig and GraphConfig work", t, func() {
 		c := NewCanvas()
 		ctx := Use(context.Background(), c)
 		XYJSON := `


### PR DESCRIPTION
These proved to be universally useful in the experiments repository, moving them here so they can be reused elsewhere.

Part of #150.