### PR TITLE
Fix fast compounding for RandDistribution

### DIFF
--- a/stats/distribution.go
+++ b/stats/distribution.go
@@ -571,14 +571,14 @@ func FastCompoundRandDistribution(ctx context.Context, source Distribution, n in
 			if len(state) > 0 {
 				state = state[1:]
 			}
-			for len(state) < n {
+			for len(state) <= n {
 				var last float64
 				if len(state) > 0 {
 					last = state[len(state)-1]
 				}
 				state = append(state, last+d.Rand())
 			}
-			return state[n-1] - state[0], state
+			return state[n] - state[0], state
 		},
 	}
 	return NewRandDistribution(ctx, source, xform, cfg)

--- a/stats/distribution_test.go
+++ b/stats/distribution_test.go
@@ -104,9 +104,9 @@ func TestDistribution(t *testing.T) {
 				Convey("fast compounding", func() {
 					d2 := FastCompoundSampleDistribution(ctx, d, 16, &cfg)
 					d2.Seed(seed)
-					So(testutil.Round(d2.Mean(), 2), ShouldEqual, 30)      // actual: 32
-					So(testutil.Round(d2.MAD(), 2), ShouldEqual, 11)       // actual: 12
-					So(testutil.Round(d2.Variance(), 2), ShouldEqual, 200) // actual: 230
+					So(testutil.Round(d2.Mean(), 2), ShouldEqual, 32)      // actual: 32
+					So(testutil.Round(d2.MAD(), 2), ShouldEqual, 12)       // actual: 12
+					So(testutil.Round(d2.Variance(), 2), ShouldEqual, 210) // actual: 230
 				})
 			})
 		})
@@ -207,7 +207,7 @@ func TestDistribution(t *testing.T) {
 			Convey("fast compounding", func() {
 				d2 := FastCompoundRandDistribution(ctx, d, 16, &compCfg)
 				d2.Seed(seed)
-				So(testutil.Round(d2.Mean(), 2), ShouldEqual, 30.0) // actual: 32
+				So(testutil.Round(d2.Mean(), 2), ShouldEqual, 32.0) // actual: 32
 				// Test MAD with up to 10% precision, hence the ratio.
 				So(testutil.Round(d.MAD()*4.0/d2.MAD(), 2), ShouldEqual, 1.0)
 			})


### PR DESCRIPTION
It was effectively compounding `n-1` samples instead of `n`.