### PR TITLE
DB: Extend db.Date to store time of day

### DIFF
--- a/db/schema.go
+++ b/db/schema.go
@@ -78,18 +78,18 @@ var _ json.Marshaler = Date{}
 var _ json.Unmarshaler = &Date{}
 var _ message.Message = &Date{}
 
-// NewDate is the constructor for Date.
+// NewDate is a Date constructor without time of the day.
 func NewDate(year uint16, month, day uint8) Date {
 	return Date{YearVal: year, MonthVal: month, DayVal: day}
 }
 
-// NewDatetime is the constructor for Date with time of the day.
+// NewDatetime is a Date constructor with time of the day.
 func NewDatetime(year uint16, month, day, hour, minute, second uint8, msec uint32) Date {
 	return Date{
 		YearVal:  year,
 		MonthVal: month,
 		DayVal:   day,
-		MsecVal:  (uint32(hour)*3600+60*uint32(minute)+uint32(second))*1000 + uint32(msec),
+		MsecVal:  (uint32(hour)*3600+uint32(minute)*60+uint32(second))*1000 + uint32(msec),
 	}
 }
 
@@ -188,7 +188,9 @@ func (d Date) ToTime() time.Time {
 		int(d.Millisecond()*1000000), time.UTC)
 }
 
-// Monday return a new Date of the Monday midnight of the current date's week.
+// Monday returns a new Date of the Monday midnight of the current date's
+// week. Note: week is assumed to start on Sunday, so Monday(d=Sunday) returns
+// the next day.
 func (d Date) Monday() Date {
 	t := d.ToTime()
 	t = t.AddDate(0, 0, 1-int(t.Weekday()))

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -57,11 +57,15 @@ func TestSchema(t *testing.T) {
 	})
 
 	Convey("Date type", t, func() {
+		Convey("has correct size", func() {
+			So(unsafe.Sizeof(Date{}), ShouldEqual, 8)
+		})
+
 		Convey("creates New York's date", func() {
-			// 2am UTC is the previous day in NY
+			// 2am UTC is 9pm the previous day in NY.
 			now := time.Date(2009, time.November, 10, 2, 0, 0, 0, time.UTC)
 			d := DateInNY(now)
-			So(d.String(), ShouldEqual, "2009-11-09")
+			So(d.String(), ShouldEqual, "2009-11-09T21:00:00.000")
 		})
 
 		Convey("converts to and from time correctly", func() {
@@ -70,6 +74,7 @@ func TestSchema(t *testing.T) {
 			So(t.Year(), ShouldEqual, d.Year())
 			So(t.Month(), ShouldEqual, d.Month())
 			So(t.Day(), ShouldEqual, d.Day())
+			So(t.Nanosecond(), ShouldEqual, 0)
 			So(NewDateFromTime(t), ShouldResemble, d)
 		})
 
@@ -81,6 +86,8 @@ func TestSchema(t *testing.T) {
 		Convey("converts to string correctly", func() {
 			d := NewDate(2019, 1, 2)
 			So(d.String(), ShouldEqual, "2019-01-02")
+			d = NewDatetime(2019, 1, 2, 15, 4, 5, 678)
+			So(d.String(), ShouldEqual, "2019-01-02T15:04:05.678")
 		})
 
 		Convey("compares the dates correctly", func() {
@@ -173,7 +180,7 @@ func TestSchema(t *testing.T) {
 
 	Convey("PriceRow", t, func() {
 		Convey("has correct size", func() {
-			So(unsafe.Sizeof(PriceRow{}), ShouldEqual, 32)
+			So(unsafe.Sizeof(PriceRow{}), ShouldEqual, 36)
 		})
 
 		Convey("TestPrice works", func() {
@@ -206,7 +213,7 @@ func TestSchema(t *testing.T) {
 
 	Convey("ResampledRow", t, func() {
 		Convey("has correct size", func() {
-			So(unsafe.Sizeof(ResampledRow{}), ShouldEqual, 44)
+			So(unsafe.Sizeof(ResampledRow{}), ShouldEqual, 52)
 		})
 
 		Convey("TestResampled works", func() {


### PR DESCRIPTION
This doubles the Date size from 4 to 8 bytes, but the change in PriceRow (the most important data entry) grows only from 32 to 36 bytes, or ~12%.

This change allows storing and processing high frequency intraday data, such as minitely bars.

Part of stockparfait/experiments#116