### PR TITLE
Add Timeseries.Filter; LogProfits can be intraday

### DIFF
--- a/db/schema.go
+++ b/db/schema.go
@@ -188,6 +188,11 @@ func (d Date) ToTime() time.Time {
 		int(d.Millisecond()*1000000), time.UTC)
 }
 
+// Date returns the date value without time of day (MsecVal = 0).
+func (d Date) Date() Date {
+	return NewDate(d.Year(), d.Month(), d.Day())
+}
+
 // Monday returns a new Date of the Monday midnight of the current date's
 // week. Note: week is assumed to start on Sunday, so Monday(d=Sunday) returns
 // the next day.

--- a/db/schema_test.go
+++ b/db/schema_test.go
@@ -136,9 +136,15 @@ func TestSchema(t *testing.T) {
 			So(d.InRange(Date{}, NewDate(2010, 3, 31)), ShouldBeFalse)
 		})
 
+		Convey("Date() works correctly", func() {
+			So(NewDatetime(2019, 1, 2, 3, 4, 5, 123).Date(), ShouldResemble, NewDate(2019, 1, 2))
+		})
+
 		Convey("Monday works correctly", func() {
 			// Jan 2, 2019 is Wednesday.
 			So(NewDate(2019, 1, 2).Monday(), ShouldResemble, NewDate(2018, 12, 31))
+			// Week starts on Sunday; Monday() becomes the next day.
+			So(NewDate(2018, 12, 30).Monday(), ShouldResemble, NewDate(2018, 12, 31))
 		})
 
 		Convey("MonthStart works correctly", func() {


### PR DESCRIPTION
Also, add `db.Date.Date()` method to drop the time of day.

Resolves #184.
Part of stockparfait/experiments#116.